### PR TITLE
Fixed not showing in jei when jea is installed

### DIFF
--- a/src/main/java/se/gory_moon/idp/client/jei/JEIPlugin.java
+++ b/src/main/java/se/gory_moon/idp/client/jei/JEIPlugin.java
@@ -20,7 +20,7 @@ public class JEIPlugin implements IModPlugin {
     private static final Logger LOGGER = LogManager.getLogger(JEIPlugin.class);
 
     @Nullable
-    public static Map<List<ItemStack>, List<Component>> preInfoData;
+    public static Map<List<ItemStack>, List<Component>> infoData;
     @Nullable
     private static IRecipeRegistration recipeRegistration;
 
@@ -32,21 +32,18 @@ public class JEIPlugin implements IModPlugin {
     @Override
     public void registerRecipes(IRecipeRegistration registration) {
         recipeRegistration = registration;
-        tryToSetData();
-    }
 
-    private void tryToSetData() {
-        if (preInfoData != null) {
-            addRecipes(preInfoData);
-            preInfoData = null;
+        // Add data if available
+        if (infoData != null) {
+            addRecipes(infoData);
         }
     }
 
     public static void addInfoRecipes(Map<List<ItemStack>, List<Component>> infoData) {
-        preInfoData = infoData;
+        JEIPlugin.infoData = infoData;
     }
 
-    private static void addRecipes(Map<List<ItemStack>, List<Component>> infoData) {
+    private void addRecipes(Map<List<ItemStack>, List<Component>> infoData) {
         LOGGER.debug("Adding ingredient info");
 
         infoData.forEach((key, value) -> {


### PR DESCRIPTION
This fixes information not showing in [JEI ](https://www.curseforge.com/minecraft/mc-mods/jei) if [JEA](https://www.curseforge.com/minecraft/mc-mods/jea) is installed as `JEA` is doing some ASM to reload `JEI` data causing double reloads and our data not being included in the second load.
Fixes #14 